### PR TITLE
fix: padded block configuration that causes ESLint v7 to fail

### DIFF
--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -362,13 +362,14 @@ module.exports = {
     // https://eslint.org/docs/rules/padded-blocks
     'padded-blocks': [
       'error',
-      'never',
       {
         blocks: 'never',
         classes: 'never',
         switches: 'never',
-        allowSingleLineBlocks: true
-      }
+      },
+      {
+        allowSingleLineBlocks: true,
+      },
     ],
 
     // require or disallow padding lines between statements


### PR DESCRIPTION
Closes #1 

## Description

Fix rule that causes ESLint v7 to fail due to rule validation checks. 